### PR TITLE
Feature - order coupon restrictions

### DIFF
--- a/src/Checkout/CheckoutFormValidatorExtension.php
+++ b/src/Checkout/CheckoutFormValidatorExtension.php
@@ -30,9 +30,10 @@ class CheckoutFormValidatorExtension extends Extension
         if ($coupon === null) {
             $this->owner->validationError(CheckoutFormExtension::COUPON_CODE_FIELD,
                 _t(self::class . '.COUPON_INVALID', 'Sorry, that coupon code is invalid.'));
-        } elseif (!$coupon->isValidFor($form->getCart())) {
-            $this->owner->validationError(CheckoutFormExtension::COUPON_CODE_FIELD,
-                _t(self::class . '.COUPON_INACTIVE', 'Sorry, that coupon is not currently available.'));
+        } else {
+            $this->owner->getResult()->combineAnd(
+                $coupon->isValidFor($form->getCart(), CheckoutFormExtension::COUPON_CODE_FIELD)
+            );
         }
     }
 }

--- a/src/OrderCoupon.php
+++ b/src/OrderCoupon.php
@@ -70,6 +70,23 @@ class OrderCoupon extends DataObject
     }
 
     /**
+     * @inheritDoc
+     */
+    public function populateDefaults()
+    {
+        parent::populateDefaults();
+
+        try {
+            // Set default random code - 4 bytes = 8 chars
+            $this->Code = bin2hex(random_bytes(4));
+        } catch (\Exception $e) {
+            throw new \RuntimeException($e->getMessage(), $e->getCode(), $e);
+        }
+
+        return $this;
+    }
+
+    /**
      * @param Order $order
      * @param string $fieldName
      * @return ValidationResult

--- a/tests/Fixtures/Coupons.yml
+++ b/tests/Fixtures/Coupons.yml
@@ -9,3 +9,11 @@ SwipeStripe\Coupons\OrderCoupon:
     Title: 20% off
     Code: twenty-percent
     Percentage: 0.2
+
+  min-ten-dollars:
+    Title: $2 off $10 or more
+    Code: min-ten-dollars
+    AmountAmount: 200
+    AmountCurrency: NZD
+    MinSubTotalAmount: 1000
+    MinSubTotalCurrency: NZD

--- a/tests/Fixtures/Coupons.yml
+++ b/tests/Fixtures/Coupons.yml
@@ -24,3 +24,8 @@ SwipeStripe\Coupons\OrderCoupon:
     AmountCurrency: NZD
     MinSubTotalAmount: 1000
     MinSubTotalCurrency: NZD
+
+  valid-to-from:
+    Title: Valid to/from
+    Code: valid-to-from
+    Percentage: 0.01

--- a/tests/Fixtures/Coupons.yml
+++ b/tests/Fixtures/Coupons.yml
@@ -10,6 +10,13 @@ SwipeStripe\Coupons\OrderCoupon:
     Code: twenty-percent
     Percentage: 0.2
 
+  fifty-percent-max-10:
+    Title: 50% off, max $10
+    Code: fifty-max-ten
+    Percentage: 0.5
+    MaxValueAmount: 1000
+    MaxValueCurrency: NZD
+
   min-ten-dollars:
     Title: $2 off $10 or more
     Code: min-ten-dollars

--- a/tests/OrderCouponTest.php
+++ b/tests/OrderCouponTest.php
@@ -162,6 +162,21 @@ class OrderCouponTest extends SapphireTest
     /**
      *
      */
+    public function testNegativeMinSubTotal()
+    {
+        $coupon = OrderCoupon::create();
+        $coupon->Title = 'Invalid';
+        $coupon->Code = $this->generateCode();
+        $coupon->Percentage = 0.5;
+        $coupon->MinSubTotal->setValue(new Money(-10, $this->getSupportedCurrencies()->getDefaultCurrency()));
+
+        $this->expectException(ValidationException::class);
+        $coupon->write();
+    }
+
+    /**
+     *
+     */
     public function testGetByCode()
     {
         $coupon = OrderCoupon::create();
@@ -237,6 +252,21 @@ class OrderCouponTest extends SapphireTest
         $this->assertTrue($twentyPercent->AmountFor($order)->getMoney()->equals(
             new Money(-600, $this->getSupportedCurrencies()->getDefaultCurrency())
         ));
+    }
+
+    /**
+     *
+     */
+    public function testIsValidForMinTotal()
+    {
+        $order = Order::singleton()->createCart();
+
+        /** @var OrderCoupon $coupon */
+        $coupon = $this->objFromFixture(OrderCoupon::class, 'min-ten-dollars');
+        $this->assertFalse($coupon->isValidFor($order)->isValid());
+
+        $order->setItemQuantity($this->product, 1);
+        $this->assertTrue($coupon->isValidFor($order)->isValid());
     }
 
     /**

--- a/tests/OrderCouponTest.php
+++ b/tests/OrderCouponTest.php
@@ -61,27 +61,10 @@ class OrderCouponTest extends SapphireTest
     {
         $coupon = OrderCoupon::create();
         $coupon->Title = 'Invalid';
-        $coupon->Code = $this->generateCode();
         $coupon->Amount->setValue(new Money(-1, $this->getSupportedCurrencies()->getDefaultCurrency()));
 
         $this->expectException(ValidationException::class);
         $coupon->write();
-    }
-
-    /**
-     * @param int $length
-     * @return string
-     */
-    protected function generateCode(int $length = 8): string
-    {
-        $bytes = intval(ceil($length / 2));
-
-        try {
-            $random = bin2hex(random_bytes($bytes));
-            return substr($random, 0, $length);
-        } catch (\Exception $e) {
-            throw new \RuntimeException($e->getMessage(), $e->getCode(), $e);
-        }
     }
 
     /**
@@ -91,7 +74,6 @@ class OrderCouponTest extends SapphireTest
     {
         $coupon = OrderCoupon::create();
         $coupon->Title = 'Invalid';
-        $coupon->Code = $this->generateCode();
 
         $this->expectException(ValidationException::class);
         $coupon->write();
@@ -104,7 +86,6 @@ class OrderCouponTest extends SapphireTest
     {
         $coupon = OrderCoupon::create();
         $coupon->Title = 'Invalid';
-        $coupon->Code = $this->generateCode();
         $coupon->Percentage = -0.5;
 
         $this->expectException(ValidationException::class);
@@ -118,7 +99,6 @@ class OrderCouponTest extends SapphireTest
     {
         $coupon = OrderCoupon::create();
         $coupon->Title = 'Invalid';
-        $coupon->Code = $this->generateCode();
         $coupon->Percentage = -0.5;
         $coupon->Amount->setValue(new Money(500, $this->getSupportedCurrencies()->getDefaultCurrency()));
 
@@ -133,7 +113,6 @@ class OrderCouponTest extends SapphireTest
     {
         $coupon = OrderCoupon::create();
         $coupon->Title = 'Valid';
-        $coupon->Code = $this->generateCode();
         $coupon->Percentage = 0.1;
         $coupon->write();
 
@@ -154,6 +133,7 @@ class OrderCouponTest extends SapphireTest
         $coupon = OrderCoupon::create();
         $coupon->Title = 'Invalid';
         $coupon->Percentage = 0.1;
+        $coupon->Code = '';
 
         $this->expectException(ValidationException::class);
         $coupon->write();
@@ -166,7 +146,6 @@ class OrderCouponTest extends SapphireTest
     {
         $coupon = OrderCoupon::create();
         $coupon->Title = 'Invalid';
-        $coupon->Code = $this->generateCode();
         $coupon->Percentage = 0.5;
         $coupon->MinSubTotal->setValue(new Money(-10, $this->getSupportedCurrencies()->getDefaultCurrency()));
 
@@ -181,7 +160,6 @@ class OrderCouponTest extends SapphireTest
     {
         $coupon = OrderCoupon::create();
         $coupon->Title = 'Invalid';
-        $coupon->Code = $this->generateCode();
         $coupon->Percentage = 0.5;
         $coupon->MaxValue->setValue(new Money(-10, $this->getSupportedCurrencies()->getDefaultCurrency()));
 
@@ -197,7 +175,6 @@ class OrderCouponTest extends SapphireTest
         $coupon = OrderCoupon::create();
         $coupon->Title = 'Valid';
         $coupon->Percentage = 0.1;
-        $coupon->Code = $this->generateCode();
         $coupon->write();
 
         $getByCode = OrderCoupon::getByCode($coupon->Code);

--- a/tests/WaitsMockTime.php
+++ b/tests/WaitsMockTime.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace SwipeStripe\Coupons\Tests;
+
+use SilverStripe\ORM\FieldType\DBDatetime;
+
+/**
+ * Trait WaitsMockTime
+ * @package SwipeStripe\Coupons\Tests
+ */
+trait WaitsMockTime
+{
+    /**
+     * @param int $seconds
+     */
+    protected function mockWait(int $seconds = 5): void
+    {
+        DBDatetime::set_mock_now(DBDatetime::now()->getTimestamp() + $seconds);
+    }
+}


### PR DESCRIPTION
Allows:
- restrict max value (`x%` off, up to max discount of `$y`)
- restrict minimum amount (`$x` or `x%` off on orders over `$y`)
- restrict coupon availability (available from `x` to `y`)