### PR TITLE
Validate already applied coupons at checkout

### DIFF
--- a/src/Checkout/CheckoutFormRequestHandlerExtension.php
+++ b/src/Checkout/CheckoutFormRequestHandlerExtension.php
@@ -5,8 +5,8 @@ namespace SwipeStripe\Coupons\Checkout;
 
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Extension;
+use SwipeStripe\Coupons\Order\OrderCoupon;
 use SwipeStripe\Coupons\Order\OrderExtension;
-use SwipeStripe\Coupons\OrderCoupon;
 use SwipeStripe\Order\Checkout\CheckoutForm;
 use SwipeStripe\Order\Checkout\CheckoutFormRequestHandler;
 use SwipeStripe\Order\Order;

--- a/src/Checkout/CheckoutFormValidatorExtension.php
+++ b/src/Checkout/CheckoutFormValidatorExtension.php
@@ -5,8 +5,10 @@ namespace SwipeStripe\Coupons\Checkout;
 
 use SilverStripe\Core\Extension;
 use SwipeStripe\Coupons\Order\OrderCoupon;
+use SwipeStripe\Coupons\Order\OrderExtension;
 use SwipeStripe\Order\Checkout\CheckoutForm;
 use SwipeStripe\Order\Checkout\CheckoutFormValidator;
+use SwipeStripe\Order\Order;
 
 /**
  * Class CheckoutFormValidatorExtension
@@ -21,6 +23,8 @@ class CheckoutFormValidatorExtension extends Extension
      */
     public function validate(CheckoutForm $form, array $data): void
     {
+        $this->owner->validateAppliedCoupons($form->getCart());
+
         $code = $data[CheckoutFormExtension::COUPON_CODE_FIELD];
         if (empty($code)) {
             return;
@@ -34,6 +38,19 @@ class CheckoutFormValidatorExtension extends Extension
             $this->owner->getResult()->combineAnd(
                 $coupon->isValidFor($form->getCart(), CheckoutFormExtension::COUPON_CODE_FIELD)
             );
+        }
+    }
+
+    /**
+     * @param Order|OrderExtension $cart
+     */
+    public function validateAppliedCoupons(Order $cart): void
+    {
+        $couponAddOn = $cart->getCouponAddOn();
+
+        if ($couponAddOn->exists()) {
+            $validationResult = $couponAddOn->OrderCoupon()->isValidFor($cart, '');
+            $this->owner->getResult()->combineAnd($validationResult);
         }
     }
 }

--- a/src/Checkout/CheckoutFormValidatorExtension.php
+++ b/src/Checkout/CheckoutFormValidatorExtension.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace SwipeStripe\Coupons\Checkout;
 
 use SilverStripe\Core\Extension;
-use SwipeStripe\Coupons\OrderCoupon;
+use SwipeStripe\Coupons\Order\OrderCoupon;
 use SwipeStripe\Order\Checkout\CheckoutForm;
 use SwipeStripe\Order\Checkout\CheckoutFormValidator;
 

--- a/src/CouponAdmin.php
+++ b/src/CouponAdmin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace SwipeStripe\Coupons;
 
 use SilverStripe\Admin\ModelAdmin;
+use SwipeStripe\Coupons\Order\OrderCoupon;
 
 /**
  * Class CouponAdmin

--- a/src/Order/OrderCoupon.php
+++ b/src/Order/OrderCoupon.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace SwipeStripe\Coupons;
+namespace SwipeStripe\Coupons\Order;
 
 use SilverStripe\Forms\FieldList;
 use SilverStripe\ORM\DataObject;
@@ -13,7 +13,7 @@ use SwipeStripe\Price\DBPrice;
 
 /**
  * Class OrderCoupon
- * @package SwipeStripe\Coupons
+ * @package SwipeStripe\Coupons\Order
  * @property string $Code
  * @property DBPrice $MinSubTotal
  * @property DBPrice $Amount

--- a/src/Order/OrderCoupon.php
+++ b/src/Order/OrderCoupon.php
@@ -103,7 +103,8 @@ class OrderCoupon extends DataObject
         $orderSubTotal = $order->SubTotal()->getMoney();
         if (!$orderSubTotal->greaterThanOrEqual($this->MinSubTotal->getMoney())) {
             $result->addFieldError($fieldName, _t(self::class . '.SUBTOTAL_TOO_LOW',
-                'Sorry, this coupon is only valid for orders of at least {min_total}.', [
+                'Sorry, the coupon "{title}" is only valid for orders of at least {min_total}.', [
+                    'title'     => $this->Title,
                     'min_total' => $this->MinSubTotal->Nice(),
                 ]));
         }
@@ -116,14 +117,16 @@ class OrderCoupon extends DataObject
 
         if ($this->ValidFrom !== null && $validFrom->getTimestamp() > $now) {
             $result->addFieldError($fieldName, _t(self::class . '.TOO_EARLY',
-                'Sorry, that coupon is not valid before {valid_from}.', [
+                'Sorry, the coupon "{title}" is not valid before {valid_from}.', [
+                    'title'      => $this->Title,
                     'valid_from' => $validFrom->Nice(),
                 ]));
         }
 
         if ($this->ValidUntil !== null && $validUntil->getTimestamp() < $now) {
             $result->addFieldError($fieldName, _t(self::class . '.TOO_LATE',
-                'Sorry, that coupon expired at {valid_until}.', [
+                'Sorry, the coupon "{title}" expired at {valid_until}.', [
+                    'title'       => $this->Title,
                     'valid_until' => $validUntil->Nice(),
                 ]));
         }

--- a/src/Order/OrderCouponAddOn.php
+++ b/src/Order/OrderCouponAddOn.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace SwipeStripe\Coupons\Order;
 
-use SwipeStripe\Coupons\OrderCoupon;
 use SwipeStripe\Order\OrderAddOn;
 use SwipeStripe\Price\DBPrice;
 

--- a/src/Order/OrderExtension.php
+++ b/src/Order/OrderExtension.php
@@ -27,14 +27,13 @@ class OrderExtension extends DataExtension
     public function getCouponAddOn(): OrderCouponAddOn
     {
         /** @var OrderCouponAddOn|null $existing */
-        $existing = OrderCouponAddOn::get_one(OrderCouponAddOn::class, ['OrderID' => $this->owner->ID]);
+        $existing = $this->owner->OrderAddOns()->find('ClassName', OrderCouponAddOn::class);
         if ($existing !== null) {
             return $existing;
         }
 
         $new = OrderCouponAddOn::create();
         $new->OrderID = $this->owner->ID;
-        $new->flushCache();
 
         return $new;
     }

--- a/tests/Fixtures/Coupons.yml
+++ b/tests/Fixtures/Coupons.yml
@@ -1,4 +1,4 @@
-SwipeStripe\Coupons\OrderCoupon:
+SwipeStripe\Coupons\Order\OrderCoupon:
   twenty-dollars:
     Title: $20 off
     Code: twenty-dollars

--- a/tests/Order/OrderCouponAddOnTest.php
+++ b/tests/Order/OrderCouponAddOnTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 namespace SwipeStripe\Coupons\Tests\Order;
 
 use SilverStripe\Dev\SapphireTest;
+use SwipeStripe\Coupons\Order\OrderCoupon;
 use SwipeStripe\Coupons\Order\OrderExtension;
-use SwipeStripe\Coupons\OrderCoupon;
 use SwipeStripe\Coupons\Tests\Fixtures\Fixtures;
 use SwipeStripe\Coupons\Tests\Fixtures\PublishesFixtures;
 use SwipeStripe\Coupons\Tests\NeedsSupportedCurrencies;

--- a/tests/Order/OrderCouponTest.php
+++ b/tests/Order/OrderCouponTest.php
@@ -1,20 +1,23 @@
 <?php
 declare(strict_types=1);
 
-namespace SwipeStripe\Coupons\Tests;
+namespace SwipeStripe\Coupons\Tests\Order;
 
 use Money\Money;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\ValidationException;
-use SwipeStripe\Coupons\OrderCoupon;
+use SwipeStripe\Coupons\Order\OrderCoupon;
 use SwipeStripe\Coupons\Tests\Fixtures\Fixtures;
 use SwipeStripe\Coupons\Tests\Fixtures\PublishesFixtures;
+use SwipeStripe\Coupons\Tests\NeedsSupportedCurrencies;
+use SwipeStripe\Coupons\Tests\TestProduct;
+use SwipeStripe\Coupons\Tests\WaitsMockTime;
 use SwipeStripe\Order\Order;
 
 /**
  * Class OrderCouponTest
- * @package SwipeStripe\Coupons\Tests
+ * @package SwipeStripe\Coupons\Tests\Order
  */
 class OrderCouponTest extends SapphireTest
 {


### PR DESCRIPTION
Stops users from applying a valid coupon, then changing their order to use the coupon in a non-qualifying manner.